### PR TITLE
fix x-rpc-sys_version fields

### DIFF
--- a/config.json
+++ b/config.json
@@ -2,7 +2,7 @@
     "token": "",
     "type": 0,
     "version": "2.2.0",
-    "android": "6.0.1",
+    "android": "",
     "deviceid": "",
     "devicename": "",
     "devicemodel": "",

--- a/config.json
+++ b/config.json
@@ -2,7 +2,7 @@
     "token": "",
     "type": 0,
     "version": "2.2.0",
-    "android": 0,
+    "android": "6.0.1",
     "deviceid": "",
     "devicename": "",
     "devicemodel": "",

--- a/main.py
+++ b/main.py
@@ -47,7 +47,7 @@ headers = {
     'x-rpc-combo_token': token,
     'x-rpc-client_type': str(client_type),
     'x-rpc-app_version': str(version),
-    'x-rpc-sys_version': str(android),
+    'x-rpc-sys_version': android
     'x-rpc-channel': 'mihoyo',
     'x-rpc-device_id': deviceid,
     'x-rpc-device_name': devicename,


### PR DESCRIPTION
实际情况中，x-rpc-sys_version若填写安卓版本可能为6.0.1，config配置中对于这个字段没有打双引号，意图是把他解析成int类型，但是类似于这样的数字是无法解析成int类型的，类似于其他的iOS，鸿蒙系统也可能会出现特殊字段，是不能用int解析的，此提交改为将他直接解析成str类型